### PR TITLE
Enable push to DockerHub

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,9 +13,7 @@ on:
       - main
 
 env:
-  # Use GH Container Registry instead of docker
-  # github.repository equals to <account|org>/<repo>
-  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: "tractusx"
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -34,20 +32,20 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-      - name: Log into registry ${{ env.REGISTRY }}
+
+      - name: DockerHub login
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v3
@@ -56,3 +54,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -57,6 +57,7 @@ jobs:
 
       # https://github.com/peter-evans/dockerhub-description
       - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Installed Versions - Dashboard
 
-This Version Dashboard provides an overview of all installed applications through [ArgoCD](https://github.com/argoproj/argo-cd/). The main purpose is to give everyone non ArgoCD focused stakeholder (Release Mgmt, Test Mgmt, Product Teams, etc.) an insight into the cluster state.
+This Version Dashboard provides an overview of all installed applications
+through [ArgoCD](https://github.com/argoproj/argo-cd/). The main purpose is to give everyone non ArgoCD focused
+stakeholder (Release Mgmt, Test Mgmt, Product Teams, etc.) an insight into the cluster state.
 
 ## How to install
+
 - Use Helm chart under /chart
 
 ## Development overview
@@ -17,12 +20,15 @@ This Version Dashboard provides an overview of all installed applications throug
   - go func() -> Uses threads for serving the dashboard independent of the update function
 
 ### External dependencies
+
 - https://fontawesome.com/docs/web/setup/host-yourself/webfonts
 - https://github.com/fiduswriter/Simple-DataTables
 
-
 ### Additional dev thoughts
-- The manual caching part could be done through nginx. Instead of delivering everything through the go code, only the dashboard itself could provide itself while nginx takes care of assets. Kept it as it is to show lowest dependency version
+
+- The manual caching part could be done through nginx. Instead of delivering everything through the go code, only the
+  dashboard itself could provide itself while nginx takes care of assets. Kept it as it is to show lowest dependency
+  version
 
 ### How to maintain this code
 
@@ -30,11 +36,31 @@ This Version Dashboard provides an overview of all installed applications throug
   - https://github.com/kubernetes/client-go
 - Update Go in the Dockerfile
 - Update Simple-DataTable
-  - Use the latest code from https://github.com/fiduswriter/Simple-DataTables through the CDN example (calling the CDN endpoint, which already contains the optimized version and save it locally)
+  - Use the latest code from https://github.com/fiduswriter/Simple-DataTables through the CDN example (calling the CDN
+    endpoint, which already contains the optimized version and save it locally)
 
 ### Development tips & tricks
+
 - Use `go mod tidy` if there are dependency issues
 - Font awesome was setup through https://fontawesome.com/docs/web/setup/host-yourself/webfonts
 - How to get the object structure from the Kubernetes API & the proper URL/Path
   - `kubectl get applications.argoproj.io`
   - Use -v=8: `kubectl -v=8 get applications.argoproj.io -n argocd`
+
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/app-dashboard](https://hub.docker.com/r/tractusx/app-dashboard)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/app-dashboard
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- License: Apache License, Version 2.0
+
+Used base image: [gcr.io/distroless/static:nonroot](https://github.com/GoogleContainerTools/distroless)
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.


### PR DESCRIPTION
This PR will add legal notices for Docker image and update the build workflow to push to DockerHub instead of GitHub container registry