### PR TITLE
fix: also show :main as unallowed image tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func transformApplicationsResponse(applicationsResponse Applications, ignoreName
 		applicationsResponse.Items[i].Status.Summary.LatestImage = false
 		applicationsResponse.Items[i].Status.Summary.PostgresqlImageFound = false
 		for _, image := range item.Status.Summary.Images {
-			if strings.Contains(image, ":latest") {
+			if strings.Contains(image, ":latest") || strings.Contains(image, ":main") {
 				applicationsResponse.Items[i].Status.Summary.LatestImage = true
 			}
 

--- a/web/template/index.html
+++ b/web/template/index.html
@@ -86,7 +86,7 @@
 
                     <li>Namespace: Shows the destination namespace</li>
                     <li>Last Sync: Shows last sync happened and the revision</li>
-                    <li>Images: Shows all used images and shows a hint if any :latest image is found</li>
+                    <li>Images: Shows all used images and shows a hint if any :latest or :main images are found</li>
                     <li>Postgresql: Shows found Postgresql image version; This gives a hint on what Postgresql version is pulled in</li>
                     <li>External Urls: Shows all configured and publicly reachable URLs of the installed application</li>
                  </ul>
@@ -143,7 +143,7 @@
             </td>
             <td class="main main-image">
                 <details>
-                    <summary>Images ({{ if .Status.Summary.LatestImage}}<span class="latest">:latest image found!</span>{{else if not .Status.Summary.LatestImage}}<span class="nolatest">No :latest image found</span>{{end}})</summary>
+                    <summary>Images ({{ if .Status.Summary.LatestImage}}<span class="latest">:latest or :main image found!</span>{{else if not .Status.Summary.LatestImage}}<span class="nolatest">No :latest or :main image found</span>{{end}})</summary>
                     <ul>
                     {{ range .Status.Summary.Images }}
                         <li>{{ image .}}</li>


### PR DESCRIPTION
Currently we only show a hint, if container image used are pulled with the :latest tag. 
This PR also adds :main to the list of unallowed tags.

