### PR TITLE
chore(build): add quality check workflow to verify TRGs

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -1,0 +1,34 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: "Quality Checks (Release Guidelines)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-quality:
+    name: Check quality guidelines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-quality-checks.yaml@main
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.idea/workspace.xml
+.idea/


### PR DESCRIPTION
## Description

This PR adds a new workflow, that checks for compliance with our Release Guidelines. 
This is achieved by reusing [this workflow](https://github.com/eclipse-tractusx/sig-infra/blob/main/.github/workflows/reusable-quality-checks.yaml) from [sig-infra](https://github.com/eclipse-tractusx/sig-infra)

Fixes #24 
