### PR TITLE
chore: run helm lint and test on larger github runner

### DIFF
--- a/.github/workflows/helm-lint-and-test.yaml
+++ b/.github/workflows/helm-lint-and-test.yaml
@@ -26,7 +26,8 @@ on:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-20.04-8core
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
---
Adding an 8 core Ubuntu 20.04 runner to the workflow
---

## Description

Thanks for opening this contribution!
_What does this PR introduce? Does it fix a bug? Does it add a new feature? Is it enhancing documentation?_

This is for testing how large GitHub Runners work. Using these runners would be indicated in the organization's billing page.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
