### PR TITLE
feat(build): add workflow to check 3rd party DEPENDENCIES

### DIFF
--- a/.github/workflows/dependencies-check.yaml
+++ b/.github/workflows/dependencies-check.yaml
@@ -1,0 +1,44 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+name: "3rd Party dependency check (Eclipse Dash)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  check-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run dash
+        id: run-dash
+        uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@feature/add-dash-action
+        with:
+          dash_input: "go.sum"
+


### PR DESCRIPTION
## Description

This PR adds a workflow, that uses [sig-infra/.github/actions/run-dash](https://github.com/eclipse-tractusx/sig-infra/tree/feature/add-dash-action/.github/actions/run-dash) action to analyze, if the 3rd party `DEPENDENCIES` are up-to-date or contain `rejected` libs.

Related to eclipse-tractusx/sig-infra#168

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] Copyright and license header are present on all affected files

## Additional Info

- The `run-dash` action (as of now) only present on a branch. As soon as it's moved to main, we should update the referenced revision to either `@main` or a tag 