### PR TITLE
fix(replace catenax-ng reference): replace catenax-ng reference

### DIFF
--- a/internal/web/container_image_to_html_test.go
+++ b/internal/web/container_image_to_html_test.go
@@ -52,8 +52,8 @@ func TestShouldRenderImagesWithNamespace(t *testing.T) {
 }
 
 func TestShouldRenderImageFromAnyContainerRegistry(t *testing.T) {
-	ghcrImage := "ghcr.io/catenax-ng/semantic-hub:0.1.0-M3"
-	expectedHtml := `<span class="host">ghcr.io</span>/<span class="image">catenax-ng/semantic-hub</span>:<span class="tag">0.1.0-M3</span>`
+	ghcrImage := "ghcr.io/eclipse-tractusx/semantic-hub:0.1.0-M3"
+	expectedHtml := `<span class="host">ghcr.io</span>/<span class="image">eclipse-tractusx/semantic-hub</span>:<span class="tag">0.1.0-M3</span>`
 
 	renderedHtml := containerImageToHtmlFunc()(ghcrImage)
 


### PR DESCRIPTION
## Description

This PR replaces the reference to "catenax-ng", since it will be archived soon. Even if it doesn't matter which URL is used, it would confuse other people.

Closes #37 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
